### PR TITLE
Fix Including Dailies for Shadowlands

### DIFF
--- a/Data.lua
+++ b/Data.lua
@@ -814,7 +814,7 @@ _V["SETTING_LIST"] = {
 			end
 			,["getValueFunc"] = function() return WQT.settings.list.alwaysAllQuests end
 			}	
-	,{["template"] = "WQT_SettingCheckboxTemplate", ["categoryID"] = "GENERAL", ["label"] = _L["INCLUDE_DAILIES"], ["tooltip"] = _L["INCLUDE_DAILIES_TT"]
+	,{["template"] = "WQT_SettingCheckboxTemplate", ["categoryID"] = "GENERAL_SHADOWLANDS", ["label"] = _L["INCLUDE_DAILIES"], ["tooltip"] = _L["INCLUDE_DAILIES_TT"]
 			, ["valueChangedFunc"] = function(value) 
 				WQT.settings.list.includeDaily = value;
 				local mapAreaID = WorldMapFrame.mapID;

--- a/WorldQuestTab.lua
+++ b/WorldQuestTab.lua
@@ -1476,7 +1476,7 @@ function WQT_ScrollListMixin:FilterQuestList()
 				passed = true;
 			else
 				-- Official filtering
-				if QuestUtils_IsQuestWorldQuest(questInfo.questID) or QuestUtils_IsQuestBonusObjective(questInfo.questID) then
+				if (questInfo.questID < 70000) or QuestUtils_IsQuestWorldQuest(questInfo.questID) or QuestUtils_IsQuestBonusObjective(questInfo.questID) then
 					passed = BlizFiltering and WorldMap_DoesWorldQuestInfoPassFilters(questInfo) or not BlizFiltering;
 					-- Add-on filters
 					if (passed and WQTFiltering) then


### PR DESCRIPTION
`L["INCLUDE_DAILIES_TT"] = "Treat certain dailies as world quests. Only affects dailies which Blizzard themselves treats as world quests."`

This setting take dailies of Shadowlands as world quests.
But Blizzard devs seemed to use different API for Dragonflight and TheWarWithin, which caused dailies, weeklies and bonus quests messy.
I think it works now, and move the setting to Shadowlands category.