### PR TITLE
Update Zone Data

### DIFF
--- a/Data.lua
+++ b/Data.lua
@@ -215,6 +215,9 @@ local WQT_LEGION = {
 	[646]	= {["x"] = 0.54, ["y"] = 0.68}, -- Broken Shore
 	[627]	= {["x"] = 0.45, ["y"] = 0.64}, -- Dalaran
 	[905] 	= {["x"] = 0.86, ["y"] = 0.17}, -- Argus
+	-- [830]	= {["x"] = 0.86, ["y"] = 0.15}, -- Krokuun
+	-- [885]	= {["x"] = 0.86, ["y"] = 0.15}, -- Antoran Wastes
+	-- [882]	= {["x"] = 0.86, ["y"] = 0.15}, -- Mac'Aree
 }
 local WQT_KALIMDOR = { 
 	[81] 	= {["x"] = 0.42, ["y"] = 0.82}, -- Silithus
@@ -322,6 +325,7 @@ local ZonesByExpansion = {
 		2248, -- Isle of Dorn
 		2255, -- Azj-Kahet
 		2256, -- Azj-Kahet - Lower
+		2339, -- Dornogal
 		2369, -- Siren Isle
 		2346, -- Undermine
 	}
@@ -1342,7 +1346,12 @@ _V["FILTER_FUNCTIONS"] = {
 -- /dump WorldMapFrame:GetMapID()
 -- /dump FlightMapFrame:GetMapID()
 _V["WQT_CONTINENT_GROUPS"] = {
-		[2200] = {1978,2133} -- Emerald Dream 
+		[2274] = {2369,2346} -- Khaz Algar
+		,[2276] = {2369,2346} -- Khaz Algar flightmap
+		,[2369] = {2274,2346} -- Siren Isle 
+		,[2346] = {2274,2369} -- Undermine 
+		,[2374] = {2274,2369} -- Undermine flightmap
+		,[2200] = {1978,2133} -- Emerald Dream 
 		,[2241] = {1978,2133} -- Emerald Dream flightmap
 		,[2133] = {1978,2200} -- Zaralek Cavern 
 		,[2175] = {1978,2200} -- Zaralek Cavern flightmap
@@ -1360,6 +1369,7 @@ _V["WQT_CONTINENT_GROUPS"] = {
 	}
 
 _V["ZONE_SUBZONES"] = {
+	[2248] = {2339, 2369}; -- Isle of Dorn, Dornogal, Siren Isle
 	[2255] = {2256, 2213, 2216}; -- Azj-Kahet, Azj-Kahet - Lower, City of Threads, City of Threads - Lower
 	[2256] = {2255, 2213, 2216}; -- Azj-Kahet - Lower, Azj-Kahet, City of Threads, City of Threads - Lower
 	[2025] = {2112, 2085}; -- Thaldraszus, Valdrakken, Primalist Future
@@ -1367,10 +1377,14 @@ _V["ZONE_SUBZONES"] = {
 	[1533] = {1707, 1708}; -- Bastion Covenant
 	[1525] = {1699, 1700}; -- Revendreth Covenant
 	[1536] = {1698}; -- Maldraxxus Covenant
+	[905]  = {830, 882, 885}; -- Krokuun, Eredath, Antoran Wastes
 }
 
 _V["WQT_ZONE_MAPCOORDS"] = {
-		[2276] = WQT_WAR_WITHIN -- Khaz Algar flightmap
+		[2374]	= { -- Undermine flightmap
+			[2346] = {["x"] = 0, ["y"] = 0} -- Undermine
+		}
+		,[2276] = WQT_WAR_WITHIN -- Khaz Algar flightmap
 		,[2274] = WQT_WAR_WITHIN -- Khaz Algar
 		,[2241]	= { -- Emerald Dream flightmap
 			[2200] = {["x"] = 0, ["y"] = 0} -- Emerald Dream
@@ -1409,14 +1423,16 @@ _V["WQT_ZONE_MAPCOORDS"] = {
 			,[50] = {["x"] = 0.67, ["y"] = 0.40} -- North
 		}
 		,[947]	= { -- All of Azeroth (Also look at UpdateAzerothZones() in Dataprovider.lua)
-			[12] = {["x"] = 0.24, ["y"] = 0.55}
+			[12] = {["x"] = 0.18, ["y"] = 0.55}
 			,[13] = {["x"] = 0.89, ["y"] = 0.52}
 			,[113] = {["x"] = 0.49, ["y"] = 0.12}
 			,[424] = {["x"] = 0.48, ["y"] = 0.82}
 			,[619] = {["x"] = 0.58, ["y"] = 0.39}
 			,[875] = {["x"] = 0.54, ["y"] = 0.63}
 			,[876] = {["x"] = 0.71, ["y"] = 0.50}
+			,[948] = {["x"] = 0.46, ["y"] = 0.48}
 			,[1978] = {["x"] = 0.77, ["y"] = 0.22}
+			,[2274] = {["x"] = 0.29, ["y"] = 0.84}
 		}
 	}
 

--- a/Dataprovider.lua
+++ b/Dataprovider.lua
@@ -25,17 +25,20 @@ local function UpdateAzerothZones(newLevel)
 	
 	-- world map continents depending on expansion level
 	worldTable[113] = {["x"] = 0.49, ["y"] = 0.12} -- Northrend
-	worldTable[424] = {["x"] = 0.48, ["y"] = 0.82} -- Pandaria
-	worldTable[12] = {["x"] = 0.24, ["y"] = 0.55} -- Kalimdor
-	worldTable[13] = {["x"] = 0.89, ["y"] = 0.52} -- Eastern Kingdom
 	
-	-- Always take the highest expansion 
-	if (expLevel >= LE_EXPANSION_DRAGONFLIGHT and newLevel >= 58) then
+	-- Always take the highest expansion
+	if (expLevel >= LE_EXPANSION_WAR_WITHIN and newLevel >= 70) then
+		worldTable[2274] = {["x"] = 0.29, ["y"] = 0.84} -- Khaz Algar
+	elseif (expLevel >= LE_EXPANSION_DRAGONFLIGHT and newLevel >= 10) then
 		worldTable[1978] = {["x"] = 0.77, ["y"] = 0.22} -- Dragon Isles
-	elseif (expLevel >= LE_EXPANSION_BATTLE_FOR_AZEROTH and newLevel >= 50) then
+	elseif (expLevel >= LE_EXPANSION_BATTLE_FOR_AZEROTH and newLevel >= 10) then
 		worldTable[875] = {["x"] = 0.54, ["y"] = 0.63} -- Zandalar
 		worldTable[876] = {["x"] = 0.71, ["y"] = 0.50} -- Kul Tiras
-	elseif (expLevel >= LE_EXPANSION_LEGION and newLevel >= 45) then
+		worldTable[12] = {["x"] = 0.18, ["y"] = 0.55} -- Kalimdor
+		worldTable[13] = {["x"] = 0.89, ["y"] = 0.52} -- Eastern Kingdom
+		worldTable[948] = {["x"] = 0.46, ["y"] = 0.48} -- The Maelstrom
+		worldTable[424] = {["x"] = 0.48, ["y"] = 0.82} -- Pandaria
+	elseif (expLevel >= LE_EXPANSION_LEGION and newLevel >= 10) then
 		worldTable[619] = {["x"] = 0.58, ["y"] = 0.39} -- Broken Isles
 	end
 end


### PR DESCRIPTION
This request includes:
1. Support for showing WQs on Undermine flight map
2. Sort `worldTable` of `UpdateAzerothZones()` which is responsible for displaying WQs on Azeroth world map.

@NanMetal , please review and check what I changed to `UpdateAzerothZones()`
Just revert these changes if you don't think it make sense.

- move Eastern Kingdom(8.1), Kalimdor(8.2, 8.3), Padaria (8.3) to BFA expansion.
- world quests of earlier expansions charater level changes to `newLevel >= 10`

Regards

